### PR TITLE
[Backend] JWT認証・ロール認可ミドルウェアの実装 (#6)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,8 @@
 import express from 'express'
 import cors from 'cors'
 import helmet from 'helmet'
+import router from './routes/index'
+import { notFoundHandler, globalErrorHandler } from './middleware/errorHandler'
 
 const app = express()
 
@@ -8,25 +10,14 @@ app.use(helmet())
 app.use(cors({ origin: process.env.FRONTEND_URL ?? 'http://localhost:5173' }))
 app.use(express.json())
 
+app.use('/api/v1', router)
+
+// Root health check
 app.get('/health', (_req, res) => {
   res.json({ status: 'success', data: { message: 'ok' } })
 })
 
-// 404 handler
-app.use((_req, res) => {
-  res.status(404).json({
-    status: 'error',
-    error: { code: 'NOT_FOUND', message: 'The requested resource was not found' },
-  })
-})
-
-// Global error handler
-app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
-  console.error(err.stack)
-  res.status(500).json({
-    status: 'error',
-    error: { code: 'INTERNAL_ERROR', message: 'An internal server error occurred' },
-  })
-})
+app.use(notFoundHandler)
+app.use(globalErrorHandler as express.ErrorRequestHandler)
 
 export default app

--- a/backend/src/lib/response.ts
+++ b/backend/src/lib/response.ts
@@ -1,0 +1,33 @@
+import type { Response } from 'express'
+
+export function success<T>(res: Response, data: T, statusCode = 200): void {
+  res.status(statusCode).json({ status: 'success', data })
+}
+
+export function paginated<T>(
+  res: Response,
+  items: T[],
+  page: number,
+  perPage: number,
+  totalCount: number
+): void {
+  const totalPages = Math.ceil(totalCount / perPage)
+  res.status(200).json({
+    status: 'success',
+    data: { items },
+    pagination: { page, per_page: perPage, total_count: totalCount, total_pages: totalPages },
+  })
+}
+
+export function error(
+  res: Response,
+  code: string,
+  message: string,
+  statusCode = 500,
+  details?: { field: string; message: string }[]
+): void {
+  res.status(statusCode).json({
+    status: 'error',
+    error: { code, message, ...(details ? { details } : {}) },
+  })
+}

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -2,7 +2,13 @@ import type { Request, Response, NextFunction } from 'express'
 import jwt from 'jsonwebtoken'
 import { error } from '../lib/response'
 
-const JWT_SECRET = process.env.JWT_SECRET ?? 'secret'
+const JWT_SECRET = (() => {
+  const secret = process.env.JWT_SECRET
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is not set')
+  }
+  return secret
+})()
 
 interface JwtPayload {
   id: number
@@ -29,7 +35,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
   const token = authHeader.slice(7)
 
   try {
-    const payload = jwt.verify(token, JWT_SECRET) as JwtPayload
+    const payload = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] }) as unknown as JwtPayload
     req.user = {
       id: payload.id,
       email: payload.email,

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -1,0 +1,58 @@
+import type { Request, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+import { error } from '../lib/response'
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'secret'
+
+interface JwtPayload {
+  id: number
+  email: string
+  position: string
+}
+
+function resolveRole(position: string): 'general' | 'manager' {
+  const managerPositions = ['KAKARICHOU', 'KACHOU', 'BUCHOU']
+  if (managerPositions.includes(position)) {
+    return 'manager'
+  }
+  return 'general'
+}
+
+export function authenticate(req: Request, res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    error(res, 'UNAUTHORIZED', '認証が必要です', 401)
+    return
+  }
+
+  const token = authHeader.slice(7)
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as JwtPayload
+    req.user = {
+      id: payload.id,
+      email: payload.email,
+      role: resolveRole(payload.position),
+    }
+    next()
+  } catch (err) {
+    error(res, 'UNAUTHORIZED', '認証が必要です', 401)
+  }
+}
+
+export function requireRole(role: 'manager' | 'general'): (req: Request, res: Response, next: NextFunction) => void {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.user) {
+      error(res, 'UNAUTHORIZED', '認証が必要です', 401)
+      return
+    }
+
+    if (role === 'manager' && req.user.role !== 'manager') {
+      error(res, 'FORBIDDEN', '権限がありません', 403)
+      return
+    }
+
+    next()
+  }
+}

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,16 @@
+import type { Request, Response, NextFunction } from 'express'
+import { error } from '../lib/response'
+
+export function notFoundHandler(_req: Request, res: Response): void {
+  error(res, 'NOT_FOUND', 'The requested resource was not found', 404)
+}
+
+export function globalErrorHandler(
+  err: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  console.error(err.stack)
+  error(res, 'INTERNAL_ERROR', 'An internal server error occurred', 500)
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express'
+
+const router = Router()
+
+router.get('/health', (_req, res) => {
+  res.json({ status: 'success', data: { message: 'ok' } })
+})
+
+export default router

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,9 @@
+declare namespace Express {
+  interface Request {
+    user?: {
+      id: number
+      email: string
+      role: 'general' | 'manager'
+    }
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,30 @@
+import axios from 'axios'
+
+const TOKEN_KEY = 'auth_token'
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY)
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token)
+}
+
+export function removeToken(): void {
+  localStorage.removeItem(TOKEN_KEY)
+}
+
+const api = axios.create({
+  baseURL: '/api/v1',
+  headers: { 'Content-Type': 'application/json' },
+})
+
+api.interceptors.request.use((config) => {
+  const token = getToken()
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+export default api

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,91 @@
+export type Role = 'general' | 'manager'
+
+export type UserInfo = {
+  id: number
+  name: string
+  email: string
+  department: string
+  position: string
+  role: Role
+}
+
+export type AuthResponse = {
+  token: string
+  expires_at: string
+  user: UserInfo
+}
+
+export type SalesPersonSummary = {
+  id: number
+  name: string
+}
+
+export type CustomerSummary = {
+  id: number
+  name: string
+}
+
+export type VisitRecord = {
+  id: number
+  customer: CustomerSummary
+  visit_content: string
+  sort_order: number
+}
+
+export type Comment = {
+  id: number
+  commenter: SalesPersonSummary
+  body: string
+  created_at: string
+}
+
+export type DailyReportSummary = {
+  id: number
+  report_date: string
+  sales_person: SalesPersonSummary
+  visit_count: number
+  comment_count: number
+  created_at: string
+  updated_at: string
+}
+
+export type DailyReportDetail = {
+  id: number
+  report_date: string
+  sales_person: SalesPersonSummary
+  visits: VisitRecord[]
+  problem: string | null
+  plan: string | null
+  comments: Comment[]
+  created_at: string
+  updated_at: string
+}
+
+export type Customer = {
+  id: number
+  name: string
+  address: string | null
+  phone: string | null
+  contact_person: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type SalesPerson = {
+  id: number
+  name: string
+  department: string
+  position: string
+  email: string
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type PaginationMeta = {
+  page: number
+  per_page: number
+  total_count: number
+  total_pages: number
+}


### PR DESCRIPTION
## Summary

- `backend/src/middleware/auth.middleware.ts` を新規作成
- `backend/src/types/express.d.ts` で `req.user` の型拡張を追加
- `authenticate` ミドルウェア: `Authorization: Bearer {token}` を検証し `req.user` をセット
- `requireRole('manager')` ミドルウェアファクトリ: ロール不足時に 403 FORBIDDEN を返す
- セキュリティ修正: アルゴリズムを `HS256` に固定、`JWT_SECRET` 未設定時に起動エラー

## Changes

### `authenticate` ミドルウェア
- ヘッダーなし / 形式不正 → 401 UNAUTHORIZED
- JWT 署名検証・有効期限チェック（`algorithms: ['HS256']` で固定）
- 検証成功時 → `req.user` に `{ id, email, role }` をセット
- `role` は `position` 文字列から決定: `KAKARICHOU/KACHOU/BUCHOU` → `manager`、`TANTO/SHUNIN` → `general`

### `requireRole` ミドルウェアファクトリ
- `req.user` なし → 401 UNAUTHORIZED
- `role === 'manager'` かつユーザーが `general` → 403 FORBIDDEN
- `role === 'general'` は全認証済みユーザー通過

## Security Fixes

| 重大度 | 内容 | 対応 |
|--------|------|------|
| CRITICAL | アルゴリズム混乱攻撃の可能性 | `jwt.verify` に `{ algorithms: ['HS256'] }` を追加 |
| HIGH | `'secret'` フォールバックによる弱シークレット | 環境変数未設定時に起動時エラーを throw |

## Test plan

- [ ] AU-020: 期限切れトークンで 401 が返ること
- [ ] AU-021: 不正トークンで 401 が返ること
- [ ] AU-022: トークンなしで 401 が返ること
- [ ] AC-005〜008: 一般ユーザーが manager ルートに 403 が返ること
- [ ] `JWT_SECRET` 未設定時にサーバー起動がエラーになること

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)