### PR TITLE
[DB] 開発・テスト用シードデータの作成 (#5)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,6 +4,12 @@ import bcrypt from 'bcryptjs'
 const prisma = new PrismaClient()
 
 async function main(): Promise<void> {
+  // 本番環境への誤適用を防ぐガード
+  if (process.env.NODE_ENV === 'production') {
+    console.error('ERROR: Seed script must not run in production.')
+    process.exit(1)
+  }
+
   console.log('Seeding database...')
 
   const hashedPassword = await bcrypt.hash('Test1234', 10)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,11 +8,12 @@ async function main(): Promise<void> {
 
   const hashedPassword = await bcrypt.hash('Test1234', 10)
 
-  // 営業担当者
-  const yamada = await prisma.salesPerson.upsert({
+  // 営業担当者（テストケースが ID を前提とするため id を明示指定）
+  await prisma.salesPerson.upsert({
     where: { email: 'yamada@example.co.jp' },
     update: {},
     create: {
+      id: 1,
       name: '山田太郎',
       department: '営業1課',
       position: Position.SHUNIN,
@@ -26,6 +27,7 @@ async function main(): Promise<void> {
     where: { email: 'sato@example.co.jp' },
     update: {},
     create: {
+      id: 2,
       name: '佐藤花子',
       department: '営業2課',
       position: Position.TANTO,
@@ -35,10 +37,11 @@ async function main(): Promise<void> {
     },
   })
 
-  const suzuki = await prisma.salesPerson.upsert({
+  await prisma.salesPerson.upsert({
     where: { email: 'suzuki@example.co.jp' },
     update: {},
     create: {
+      id: 3,
       name: '鈴木課長',
       department: '営業1課',
       position: Position.KACHOU,
@@ -48,11 +51,12 @@ async function main(): Promise<void> {
     },
   })
 
-  // 無効ユーザー
+  // 無効ユーザー（is_active = false でログイン不可）
   await prisma.salesPerson.upsert({
     where: { email: 'invalid@example.co.jp' },
     update: {},
     create: {
+      id: 4,
       name: '無効ユーザー',
       department: '営業1課',
       position: Position.TANTO,
@@ -62,8 +66,14 @@ async function main(): Promise<void> {
     },
   })
 
-  // 顧客
-  const abc = await prisma.customer.upsert({
+  // シーケンスを最大IDに合わせてリセット（PostgreSQL）
+  // autoincrement が4以降から採番されるよう調整する
+  await prisma.$executeRawUnsafe(
+    `SELECT setval(pg_get_serial_sequence('sales_persons', 'id'), GREATEST((SELECT MAX(id) FROM sales_persons), 1))`
+  )
+
+  // 顧客（ID 固定指定）
+  await prisma.customer.upsert({
     where: { id: 10 },
     update: {},
     create: {
@@ -102,27 +112,32 @@ async function main(): Promise<void> {
     },
   })
 
-  // サンプル日報
+  // customers シーケンスも同様にリセット
+  await prisma.$executeRawUnsafe(
+    `SELECT setval(pg_get_serial_sequence('customers', 'id'), GREATEST((SELECT MAX(id) FROM customers), 1))`
+  )
+
+  // サンプル日報（山田太郎の当日分）
   const today = new Date()
   today.setHours(0, 0, 0, 0)
 
   const report = await prisma.dailyReport.upsert({
     where: {
       salesPersonId_reportDate: {
-        salesPersonId: yamada.id,
+        salesPersonId: 1,
         reportDate: today,
       },
     },
     update: {},
     create: {
-      salesPersonId: yamada.id,
+      salesPersonId: 1,
       reportDate: today,
       problem: 'ABC社への見積もり金額について相談したい。',
       plan: 'ABC社向け見積書作成、XYZ社へ対応報告メール送付。',
       visitRecords: {
         create: [
           {
-            customerId: abc.id,
+            customerId: 10,
             visitContent: '新製品の提案を実施。次回見積もり提出予定。',
             sortOrder: 1,
           },
@@ -131,17 +146,22 @@ async function main(): Promise<void> {
     },
   })
 
-  // サンプルコメント
+  // サンプルコメント（鈴木課長から）
   await prisma.comment.upsert({
     where: { id: 1 },
     update: {},
     create: {
       id: 1,
       dailyReportId: report.id,
-      commenterId: suzuki.id,
+      commenterId: 3,
       body: 'ABC社の見積もりは明日の朝会で一緒に確認しよう。',
     },
   })
+
+  // comments シーケンスをリセット
+  await prisma.$executeRawUnsafe(
+    `SELECT setval(pg_get_serial_sequence('comments', 'id'), GREATEST((SELECT MAX(id) FROM comments), 1))`
+  )
 
   console.log('Seeding completed.')
 }


### PR DESCRIPTION
## Summary

- `prisma/seed.ts` の営業担当者（`SalesPerson`）upsert に `id` フィールドを明示指定（1=山田太郎, 2=佐藤花子, 3=鈴木課長, 4=無効ユーザー）
- `yamada.id` / `suzuki.id` / `abc.id` などの変数参照をリテラルIDに統一し、固定ID方針と一貫させた
- PostgreSQL の `autoincrement` シーケンスを seed 後に `setval` でリセットし、手動指定IDと後続の自動採番が衝突しないよう対処
- `package.json` の `prisma.seed` フィールドが `"node --import tsx/esm prisma/seed.ts"` で正しく設定済みであることを確認
- `bcryptjs` によるパスワードハッシュ化（平文: `Test1234`、salt rounds: 10）が正しく実装されていることを確認
- 全エンティティで `upsert` を使用しているため、再実行しても重複エラーが発生しない

## 受け入れ条件確認

| 条件 | 状態 |
|------|------|
| `prisma/seed.ts` が存在する | 済 |
| `package.json` の `prisma.seed` フィールドに登録済み | 済（`"node --import tsx/esm prisma/seed.ts"`） |
| `bcrypt` でパスワードをハッシュ化（平文: `Test1234`） | 済（`bcryptjs`, salt rounds: 10） |
| `upsert` を使い再実行しても重複エラーが起きない | 済（email / id での upsert） |
| 営業担当者の ID が固定されている（ID:1〜4） | 済（create ブロックに `id` を明示指定） |
| ID 指定後のシーケンス整合性を確保 | 済（`setval` でシーケンスをリセット） |

## Test plan

- [ ] `npx prisma db seed` を実行し正常終了することを確認
- [ ] 再実行してもエラーが発生しないことを確認
- [ ] 営業担当者の ID が 1〜4 であることを DB で確認
- [ ] 顧客の ID が 10, 20, 30 であることを DB で確認
- [ ] `invalid@example.co.jp` の `is_active` が `false` であることを確認
- [ ] ログイン API で `yamada@example.co.jp` / `Test1234` が認証成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)