### PR TITLE
feat: [Backend] 日報一覧取得 API (GET /daily-reports) #9

### DIFF
--- a/backend/src/controllers/daily-reports.controller.ts
+++ b/backend/src/controllers/daily-reports.controller.ts
@@ -1,0 +1,150 @@
+import type { Request, Response } from 'express'
+import { query, validationResult } from 'express-validator'
+import { prisma } from '../lib/prisma'
+import { paginated, error } from '../lib/response'
+
+/**
+ * Query parameter validation rules for GET /daily-reports
+ */
+export const getDailyReportsValidation = [
+  query('date_from')
+    .optional()
+    .isISO8601()
+    .withMessage('date_from は YYYY-MM-DD 形式で入力してください'),
+  query('date_to')
+    .optional()
+    .isISO8601()
+    .withMessage('date_to は YYYY-MM-DD 形式で入力してください'),
+  query('sales_person_id')
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage('sales_person_id は正の整数で入力してください')
+    .toInt(),
+  query('page')
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage('page は1以上の整数で入力してください')
+    .toInt(),
+  query('per_page')
+    .optional()
+    .isInt({ min: 1, max: 100 })
+    .withMessage('per_page は1〜100の整数で入力してください')
+    .toInt(),
+]
+
+/**
+ * GET /daily-reports
+ *
+ * Retrieves a paginated list of daily reports with optional date range
+ * and sales person filtering. General users can only see their own reports;
+ * managers can see all reports.
+ */
+export async function getDailyReports(req: Request, res: Response): Promise<void> {
+  // Validate query parameters
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    const details = errors.array().map((err) => ({
+      field: 'msg' in err && 'path' in err ? (err as { path: string }).path : 'unknown',
+      message: err.msg as string,
+    }))
+    error(res, 'VALIDATION_ERROR', '入力内容に誤りがあります', 400, details)
+    return
+  }
+
+  const user = req.user
+  if (!user) {
+    error(res, 'UNAUTHORIZED', '認証が必要です', 401)
+    return
+  }
+
+  // Parse query parameters with defaults
+  const now = new Date()
+  const defaultDateTo = formatDate(now)
+  const defaultDateFrom = formatDate(new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000))
+
+  const dateFrom = (req.query.date_from as string) || defaultDateFrom
+  const dateTo = (req.query.date_to as string) || defaultDateTo
+  const page = typeof req.query.page === 'number' ? req.query.page : 1
+  const perPage = typeof req.query.per_page === 'number' ? req.query.per_page : 20
+
+  // Build sales_person_id filter based on role
+  let salesPersonIdFilter: number | undefined
+  if (user.role === 'general') {
+    // General users can only see their own reports
+    salesPersonIdFilter = user.id
+  } else {
+    // Managers can filter by any sales_person_id, or see all
+    salesPersonIdFilter = typeof req.query.sales_person_id === 'number'
+      ? req.query.sales_person_id
+      : undefined
+  }
+
+  // Build Prisma where clause
+  const where = {
+    reportDate: {
+      gte: new Date(dateFrom),
+      lte: new Date(dateTo),
+    },
+    ...(salesPersonIdFilter !== undefined && { salesPersonId: salesPersonIdFilter }),
+  }
+
+  try {
+    // Execute count and findMany in parallel for efficiency
+    const [totalCount, reports] = await Promise.all([
+      prisma.dailyReport.count({ where }),
+      prisma.dailyReport.findMany({
+        where,
+        select: {
+          id: true,
+          reportDate: true,
+          createdAt: true,
+          updatedAt: true,
+          salesPerson: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          _count: {
+            select: {
+              visitRecords: true,
+              comments: true,
+            },
+          },
+        },
+        orderBy: { reportDate: 'desc' },
+        skip: (page - 1) * perPage,
+        take: perPage,
+      }),
+    ])
+
+    // Transform to API response format
+    const items = reports.map((report) => ({
+      id: report.id,
+      report_date: formatDate(report.reportDate),
+      sales_person: {
+        id: report.salesPerson.id,
+        name: report.salesPerson.name,
+      },
+      visit_count: report._count.visitRecords,
+      comment_count: report._count.comments,
+      created_at: report.createdAt.toISOString(),
+      updated_at: report.updatedAt.toISOString(),
+    }))
+
+    paginated(res, items, page, perPage, totalCount)
+  } catch (err) {
+    console.error('Error fetching daily reports:', err)
+    error(res, 'INTERNAL_ERROR', 'サーバー内部エラーが発生しました', 500)
+  }
+}
+
+/**
+ * Formats a Date object to YYYY-MM-DD string.
+ */
+function formatDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}

--- a/backend/src/controllers/daily-reports.controller.ts
+++ b/backend/src/controllers/daily-reports.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express'
-import { query, validationResult } from 'express-validator'
+import { query, validationResult, matchedData } from 'express-validator'
 import { prisma } from '../lib/prisma'
 import { paginated, error } from '../lib/response'
 
@@ -9,12 +9,16 @@ import { paginated, error } from '../lib/response'
 export const getDailyReportsValidation = [
   query('date_from')
     .optional()
-    .isISO8601()
-    .withMessage('date_from は YYYY-MM-DD 形式で入力してください'),
+    .matches(/^\d{4}-\d{2}-\d{2}$/)
+    .withMessage('date_from は YYYY-MM-DD 形式で入力してください')
+    .isDate()
+    .withMessage('date_from は有効な日付を入力してください'),
   query('date_to')
     .optional()
-    .isISO8601()
-    .withMessage('date_to は YYYY-MM-DD 形式で入力してください'),
+    .matches(/^\d{4}-\d{2}-\d{2}$/)
+    .withMessage('date_to は YYYY-MM-DD 形式で入力してください')
+    .isDate()
+    .withMessage('date_to は有効な日付を入力してください'),
   query('sales_person_id')
     .optional()
     .isInt({ min: 1 })
@@ -44,7 +48,7 @@ export async function getDailyReports(req: Request, res: Response): Promise<void
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
     const details = errors.array().map((err) => ({
-      field: 'msg' in err && 'path' in err ? (err as { path: string }).path : 'unknown',
+      field: 'path' in err ? (err as { path: string }).path : 'unknown',
       message: err.msg as string,
     }))
     error(res, 'VALIDATION_ERROR', '入力内容に誤りがあります', 400, details)
@@ -57,26 +61,42 @@ export async function getDailyReports(req: Request, res: Response): Promise<void
     return
   }
 
+  // matchedData() でバリデーション・サニタイズ済みの値を取得する
+  // （express-validator の .toInt() は req.query を直接変換しないため、
+  //   matchedData() 経由で取得しないと型変換が反映されない）
+  const validated = matchedData(req) as {
+    date_from?: string
+    date_to?: string
+    sales_person_id?: number
+    page?: number
+    per_page?: number
+  }
+
   // Parse query parameters with defaults
   const now = new Date()
   const defaultDateTo = formatDate(now)
   const defaultDateFrom = formatDate(new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000))
 
-  const dateFrom = (req.query.date_from as string) || defaultDateFrom
-  const dateTo = (req.query.date_to as string) || defaultDateTo
-  const page = typeof req.query.page === 'number' ? req.query.page : 1
-  const perPage = typeof req.query.per_page === 'number' ? req.query.per_page : 20
+  const dateFrom = validated.date_from ?? defaultDateFrom
+  const dateTo = validated.date_to ?? defaultDateTo
+  const page = validated.page ?? 1
+  const perPage = validated.per_page ?? 20
+
+  // date_from > date_to のクロスフィールドバリデーション（テストケース DL-015）
+  if (new Date(dateFrom) > new Date(dateTo)) {
+    error(res, 'VALIDATION_ERROR', 'date_from は date_to 以前の日付を指定してください', 400)
+    return
+  }
 
   // Build sales_person_id filter based on role
   let salesPersonIdFilter: number | undefined
   if (user.role === 'general') {
-    // General users can only see their own reports
+    // 一般ユーザーは自分の日報のみ閲覧可能。
+    // クエリパラメータの sales_person_id は無視し、認証済みユーザーのIDを強制する。
     salesPersonIdFilter = user.id
   } else {
-    // Managers can filter by any sales_person_id, or see all
-    salesPersonIdFilter = typeof req.query.sales_person_id === 'number'
-      ? req.query.sales_person_id
-      : undefined
+    // 上長は任意の sales_person_id で絞り込み可能（未指定時は全員分）
+    salesPersonIdFilter = validated.sales_person_id
   }
 
   // Build Prisma where clause
@@ -134,7 +154,8 @@ export async function getDailyReports(req: Request, res: Response): Promise<void
 
     paginated(res, items, page, perPage, totalCount)
   } catch (err) {
-    console.error('Error fetching daily reports:', err)
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    console.error('Error fetching daily reports:', message)
     error(res, 'INTERNAL_ERROR', 'サーバー内部エラーが発生しました', 500)
   }
 }

--- a/backend/src/routes/daily-reports.routes.ts
+++ b/backend/src/routes/daily-reports.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express'
+import { authenticate } from '../middleware/auth.middleware'
+import {
+  getDailyReports,
+  getDailyReportsValidation,
+} from '../controllers/daily-reports.controller'
+
+const router = Router()
+
+// GET /daily-reports - Retrieve paginated list of daily reports
+router.get('/', authenticate, getDailyReportsValidation, getDailyReports)
+
+export default router

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,9 +1,12 @@
 import { Router } from 'express'
+import dailyReportsRouter from './daily-reports.routes'
 
 const router = Router()
 
 router.get('/health', (_req, res) => {
   res.json({ status: 'success', data: { message: 'ok' } })
 })
+
+router.use('/daily-reports', dailyReportsRouter)
 
 export default router


### PR DESCRIPTION
## Summary
- 日報一覧取得 API (`GET /api/v1/daily-reports`) を実装
- 日付範囲フィルタ（デフォルト: 直近7日間）、営業担当者フィルタ、ページネーション対応
- ロールベースのアクセス制御（一般: 自分の日報のみ / 上長: 全員の日報）
- 訪問件数・コメント数を Prisma `_count` で効率的に集計
- `express-validator` によるクエリパラメータバリデーション

## 変更ファイル
- `backend/src/controllers/daily-reports.controller.ts` (新規)
- `backend/src/routes/daily-reports.routes.ts` (新規)
- `backend/src/routes/index.ts` (ルート登録追加)

## 対応する受け入れ条件
- [x] 初期表示（直近1週間）が正しく返る（DL-001, DL-002）
- [x] 一般ユーザーは自分の日報のみ取得できる（AC-001）
- [x] 上長は全営業担当者の日報を取得できる（AC-002）
- [x] 日付範囲で絞り込みができる（DL-010）
- [x] `sales_person_id` で絞り込みができる（DL-011）
- [x] 報告日の降順でソートされる（DL-005）
- [x] ページネーション情報（`pagination` オブジェクト）が返る
- [x] 20件超でページネーションが機能する（DL-020）
- [x] 0件の場合に空配列が返る（DL-014）

## Test plan
- [ ] TypeScript型チェック (`npx tsc --noEmit`) パス済み
- [ ] ESLint チェック パス済み
- [ ] 一般ユーザーで日報一覧取得 → 自分の日報のみ返却されること
- [ ] 上長ユーザーで日報一覧取得 → 全員の日報が返却されること
- [ ] date_from/date_to で日付範囲絞り込みができること
- [ ] sales_person_id で営業担当者絞り込みができること
- [ ] ページネーションが正しく動作すること

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)